### PR TITLE
Adds code for PSCore on Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,11 @@ if($Development) {
         $modules = [IO.DirectoryInfo]"~/.local/share/powershell/Modules";
     } else {
         $docs = [Environment]::GetFolderPath("mydocuments");
-        $modules = [IO.DirectoryInfo]"$docs\WindowsPowerShell\Modules";
+        if ($PSEdition -eq 'Core') {
+            $modules = [IO.DirectoryInfo]"$docs\PowerShell\Modules";
+        } else {
+            $modules = [IO.DirectoryInfo]"$docs\WindowsPowerShell\Modules";
+        }
     }
     if(! $modules.Exists) {
         [IO.Directory]::CreateDirectory($modules.FullName);


### PR DESCRIPTION
Just tried installing this on PSCore on Windows and noticed that the path to the modules was not correct. Could maybe use `$env:PSModulePath`, but then you'd have to figure out whether or not we should split on ';' or ':'

